### PR TITLE
Changed MinimumScale and Maximum Scale to double?

### DIFF
--- a/src/Anywhere.ArcGIS/Operation/ServiceLayerDescription.cs
+++ b/src/Anywhere.ArcGIS/Operation/ServiceLayerDescription.cs
@@ -61,10 +61,10 @@
         public List<RelatedLayer> SubLayers { get; set; }
 
         [DataMember(Name = "minScale")]
-        public int MinimumScale { get; set; }
+        public double? MinimumScale { get; set; }
 
         [DataMember(Name = "maxScale")]
-        public int MaximumScale { get; set; }
+        public double? MaximumScale { get; set; }
 
         [DataMember(Name = "defaultVisibility")]
         public bool DefaultVisibility { get; set; }

--- a/tests/Anywhere.ArcGIS.Test.Integration/ArcGISGatewayTests.cs
+++ b/tests/Anywhere.ArcGIS.Test.Integration/ArcGISGatewayTests.cs
@@ -135,7 +135,7 @@
         [Theory]
         [InlineData("http://sampleserver3.arcgisonline.com/ArcGIS/", "Petroleum/KSWells/MapServer/0")]
         [InlineData("http://sampleserver3.arcgisonline.com/ArcGIS/", "Petroleum/KSWells/MapServer/1")]
-        [InlineData("http://services.arcgisonline.co.nz/arcgis", "Canvas/Light/MapServer/0”)]
+        [InlineData("http://services.arcgisonline.co.nz/arcgis", "Canvas/Light/MapServer/0")]
         [InlineData("http://services1.arcgis.com/dOFzdrPdRgtU4fRo/ArcGIS", "ServiceDefDouble/FeatureServer/0")]
         public async Task CanDescribeLayer(string rootUrl, string layerUrl)
         {

--- a/tests/Anywhere.ArcGIS.Test.Integration/ArcGISGatewayTests.cs
+++ b/tests/Anywhere.ArcGIS.Test.Integration/ArcGISGatewayTests.cs
@@ -135,7 +135,8 @@
         [Theory]
         [InlineData("http://sampleserver3.arcgisonline.com/ArcGIS/", "Petroleum/KSWells/MapServer/0")]
         [InlineData("http://sampleserver3.arcgisonline.com/ArcGIS/", "Petroleum/KSWells/MapServer/1")]
-        [InlineData("http://services.arcgisonline.co.nz/arcgis", "Canvas/Light/MapServer/0")]
+        [InlineData("http://services.arcgisonline.co.nz/arcgis", "Canvas/Light/MapServer/0”)]
+        [InlineData("http://services1.arcgis.com/dOFzdrPdRgtU4fRo/ArcGIS", "ServiceDefDouble/FeatureServer/0")]
         public async Task CanDescribeLayer(string rootUrl, string layerUrl)
         {
             var gateway = new PortalGateway(rootUrl);


### PR DESCRIPTION
#46 
Changed int to double? for both parameters. Added a test service to CanDescribeLayer that has a double MinScale. It will fail on older builds and pass with the change to double.